### PR TITLE
Improve `git log` parsing

### DIFF
--- a/mkdocs_git_latest_changes_plugin/plugin.py
+++ b/mkdocs_git_latest_changes_plugin/plugin.py
@@ -178,7 +178,7 @@ def get_recent_changes(*, repo_url: str, repo_name: str) -> str:
         files = files.split("\n")
 
     loginfos = []
-    ok_keys = { 'Timestamp': True, 'hash_short': True, 'hash_full': True, 'author': True, 'date': True, 'message': True }
+    ok_keys = { 'Timestamp', 'hash_short', 'hash_full', 'author', 'date', 'message' }
     for file in files:
         log.debug(f"Processing file `{file}`...")
 

--- a/mkdocs_git_latest_changes_plugin/plugin.py
+++ b/mkdocs_git_latest_changes_plugin/plugin.py
@@ -193,7 +193,7 @@ def get_recent_changes(*, repo_url: str, repo_name: str) -> str:
             for line in loginfo.splitlines():
                 k, v = line.split(":", maxsplit=1)
                 if k not in ok_keys:
-                    raise ValueError(f"Unexpected key parsed from `git log`: {k}")
+                    raise KeyError(f"Unexpected key parsed from `git log`: '{k}'")
                 tmpdict[k] = sanitize(v)
             loginfo = tmpdict
 


### PR DESCRIPTION
Before this patch, double quotes (") in commit message subjects break the pseudo-JSON the "--pretty" option's format string tries to wrestle from `git log`.

With this patch, `git log` is made to emit a newline-delimited representation of each commit, which is then parsed and (weakly) validated, and ends up in a dict without intermittent JSONification.

Further hardening against (accidental) injections via `git log` output might be a good idea still.